### PR TITLE
CI: Use Flutter instead of dart for format CI

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -21,8 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup dart
-        uses: dart-lang/setup-dart@v1
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version-file: pubspec.yaml
       - name: Format code
         run: dart format --output=none --set-exit-if-changed .
   matrics:


### PR DESCRIPTION
This PR updates CI configuration to use Flutter instead of dart for formatting.